### PR TITLE
SimpleTimer "_elapsedTime" metrics must be of type "gauge" for Prometheus

### DIFF
--- a/core/src/main/java/com/kumuluz/ee/metrics/prometheus/PrometheusBuilder.java
+++ b/core/src/main/java/com/kumuluz/ee/metrics/prometheus/PrometheusBuilder.java
@@ -82,7 +82,7 @@ public class PrometheusBuilder {
         String lineName = name + "_elapsedTime";
         double value = simpleTimer.getElapsedTime().toNanos() * conversionFactor;
 
-        getPromTypeLine(builder, lineName, "simpletimer");
+        getPromTypeLine(builder, lineName, "gauge");
         getPromValueLine(builder, lineName, value, tags, "_seconds");
     }
 


### PR DESCRIPTION
SimpleTimer "_elapsedTime" metrics must be of type "gauge" for Prometheus. "simpleTime/simpletime" is not know to prometheus

(Sorry for the wrong previous PR. I tested it this time!)